### PR TITLE
test&build_process_relocation_to_composer_file__&__directus_service_h…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./middleware
       dockerfile: Dockerfile
     restart: unless-stopped
-    command: sh -c "wait && npm run dev"
+    command: sh -c "wait && npm run test && npm run build && npm run dev"
     volumes:
       - ./middleware/src:/app/src
       - ./middleware/tsconfig.json:/app/tsconfig.json
@@ -110,10 +110,10 @@ services:
 
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8055/admin || exit 1
-      interval: 1s
-      timeout: 1s
+      interval: 3s
+      timeout: 3s
       retries: 30
-      start_period: 1s
+      start_period: 5s
 
 volumes:
   rts_directus_db_volume:

--- a/middleware/Dockerfile
+++ b/middleware/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install
 
 COPY . .
 
-RUN npm run test && npm run build
+# RUN npm run test && npm run build
 
 EXPOSE 8000
 


### PR DESCRIPTION
# Docker files edit for service build and startup
after following the required steps
- [x] Run `docker volume create rts_directus_db_volume`
- [x] Run `docker-compose up` in your root repository directory and keep  its terminal open

I obtained the following Error

```bash
> real-time-socket@1.0.0 test
> jest

 PASS  src/services/authorization/healthSevice.spec.ts
  Test health service
    √ should succeed to return the `pong` message (16 ms)

 FAIL  src/services/room/roomService.spec.ts
  ● Test suite failed to run

    TypeError: Invalid URL

      13 | export type BackendKeys = keyof Backend;
      14 |
    > 15 | export const client = createDirectus<Backend>(
         |                                     ^
      16 |   APPCONFIGS.DIRECTUS.ENDPOINT as string
      17 | )
      18 |   .with(rest())

      at ee (node_modules/@directus/sdk/dist/https:/raw.githubusercontent.com/directus/directus/v10.10.3/sdk/src/client.ts:28:8)
      at Object.<anonymous> (src/directus/directus.ts:15:37)
      at Object.require (src/directus/index.ts:1:1)
      at Object.require (src/services/utils/simpleDataService.ts:1:1)
      at Object.require (src/services/utils/index.ts:1:1)
      at Object.require (src/services/auth/authService.ts:5:1)
      at Object.require (src/services/auth/index.ts:1:1)
      at Object.require (src/services/index.ts:2:1)
      at Object.require (src/utils/auth/authUtils.ts:3:1)
      at Object.require (src/utils/auth/index.ts:1:1)
      at Object.require (src/services/room/roomService.ts:2:1)
      at Object.require (src/services/room/roomService.spec.ts:1:1)

------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|-------------------
All files         |     100 |      100 |     100 |     100 | 
 healthService.ts |     100 |      100 |     100 |     100 | 
------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        10.756 s
Ran all test suites.
```
after checking, this error was caused by the undefined state of the **environmental variable** `DIRECTUS_ENDPOINT` which remains undefined until a value is attributed to it during the service startup based on the docker compose file.

## Problem found

the service does not startup due to the build process of the middleware service which is running the test suit in the service build process and requires this variable `DIRECTUS_ENDPOINT` to be defined, to correctly access the directus service, but the value is defined only when all the images are created and the container build following the docker compose file.
```bash
FROM node:21-alpine3.18

RUN apk update && apk add --no-cache curl file && rm -rf /var/lib/apt/lists/*

WORKDIR /app

COPY package*.json ./

RUN npm install

COPY . .

RUN npm run test && npm run build   # problematic line

EXPOSE 8000

CMD ["npm", "run", "start"]
```

## Proposed solution

moving the below command to the docker compose file under the middle ware container service.
```bash
npm run test && npm run build
```
to
```yaml
  services:
    middleware:
      container_name: middleware
      build:
        context: ./middleware
        dockerfile: Dockerfile
     restart: unless-stopped
     command: sh -c "wait && npm run dev"      # removed
     command: sh -c "wait && npm run test && npm run build && npm run dev"
    ...
```
I also made some changes to the directus service for a better health check
```yaml
  directus:
    container_name: directus
    build: ./directus
    ...
    healthcheck:
      test: wget --no-verbose --tries=1 --spider http://localhost:8055/admin || exit 1
      interval: 3s      # added 2s
      timeout: 3s     # added 2s
      retries: 30
      start_period: 5s   # added 4s
```